### PR TITLE
add Dependency Container initial implementation

### DIFF
--- a/DependencyContainer/Sources/DependencyContainer.swift
+++ b/DependencyContainer/Sources/DependencyContainer.swift
@@ -14,4 +14,60 @@
 //===----------------------------------------------------------------------===//
 //
 
+
+
 import Foundation
+
+@MainActor
+public final class DependencyContainer {
+    private var storage = [Key: Any]()
+    
+    struct Key: Hashable {
+        let interface: String
+        let consumer: String
+    }
+    
+    public static let `default` = DependencyContainer()
+    
+    func key<Interface, Consumer>(
+        of interface: Interface.Type,
+        for consumer: Consumer.Type = Any.self
+    ) -> Key {
+        return Key(
+            interface: String(reflecting: interface),
+            consumer: String(reflecting: consumer)
+        )
+    }
+
+    func inject<Interface, Consumer, Instance>(
+        _ instance: Instance,
+        of interface: Interface.Type,
+        for consumer: Consumer.Type
+    ) {
+        let key = key(of: interface, for: consumer)
+        storage[key] = instance
+    }
+    
+    func injectGlobal<Interface, Instance>(
+        _ instance: Instance,
+        of interface: Interface.Type
+    ) {
+        let key = key(of: interface)
+        storage[key] = instance
+    }
+    
+    func instance<Interface, Consumer, Instance>(
+        of interface: Interface.Type,
+        for consumer: Consumer.Type = Any.self
+    ) -> Instance? {
+        instance(
+            for: key(of: interface, for: consumer)
+        ) as? Instance
+    }
+    
+    func instance(for key: Key) -> Any? {
+        return storage[key]
+    }
+}
+
+

--- a/DependencyContainer/Sources/Injected+Wrapper.swift
+++ b/DependencyContainer/Sources/Injected+Wrapper.swift
@@ -1,0 +1,66 @@
+//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Decore package open source project
+//
+// Copyright (c) 2020-2022 Maxim Bazarov and the Decore package 
+// open source project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+//
+
+import Foundation
+
+@MainActor
+@propertyWrapper public struct Injected<Value> {
+    
+    typealias Key = DependencyContainer.Key
+    
+    public var wrappedValue: Value {
+        return instance() ?? defaultInstance()
+    }
+    
+    var instance: () -> Value?
+    var defaultInstance: () -> Value
+    
+    public init<Consumer>(
+        wrappedValue: @escaping () -> Value,
+        as interface: Value.Type,
+        into consumer: Consumer.Type,
+        file: String = #file,
+        fileID: String = #fileID,
+        line: Int = #line,
+        column: Int = #column,
+        function: String = #function
+    ) {
+        let container = DependencyContainer.default
+        defaultInstance = wrappedValue
+        instance = {
+            container.instance(of: interface, for: consumer)
+        }
+        container.inject(wrappedValue(), of: interface, for: consumer)
+    }
+    
+    public init(
+        wrappedValue: @escaping () -> Value,
+        as interface: Value.Type,
+        file: String = #file,
+        fileID: String = #fileID,
+        line: Int = #line,
+        column: Int = #column,
+        function: String = #function
+    ) {
+        let container = DependencyContainer.default
+        defaultInstance = wrappedValue
+        instance = {
+            container.instance(of: interface)
+        }
+        container.injectGlobal(wrappedValue(), of: interface)
+    }
+
+}

--- a/DependencyContainer/Tests/DependencyContainer-Tests.swift
+++ b/DependencyContainer/Tests/DependencyContainer-Tests.swift
@@ -14,4 +14,51 @@
 //===----------------------------------------------------------------------===//
 //
 
-import Foundation
+import XCTest
+@testable import DependencyContainer
+
+private protocol Interface: AnyObject {}
+private final class InterfaceMock: Interface {}
+
+@MainActor
+final class DependencyContainer_Tests: XCTestCase {
+    
+    func test_Injected_then_returnsDefaultInstance() throws {
+        let defaultInstance = InterfaceMock()
+        @Injected(as: Interface.self) var sut = { defaultInstance }
+        
+        XCTAssertEqual(ObjectIdentifier(defaultInstance), ObjectIdentifier(sut))
+    }
+    
+    func test_Injected_Global_when_injectGlobal_then_returnsInjectedInstance() throws {
+        let defaultInstance = InterfaceMock()
+        let injectedInstance = InterfaceMock()
+        @Injected(as: Interface.self) var sut = { defaultInstance }
+        
+        DependencyContainer.default.injectGlobal(injectedInstance, of: Interface.self)
+        
+        XCTAssertEqual(ObjectIdentifier(injectedInstance), ObjectIdentifier(sut))
+    }
+    
+    func test_Injected_Global_when_injectForConsumer_then_returnsDefault() throws {
+        let defaultInstance = InterfaceMock()
+        let injectedInstance = InterfaceMock()
+        @Injected(as: Interface.self) var sut = { defaultInstance }
+        
+        DependencyContainer.default
+            .inject(injectedInstance, of: Interface.self, for: Self.self)
+        
+        XCTAssertEqual(ObjectIdentifier(defaultInstance), ObjectIdentifier(sut))
+    }
+    
+    func test_Injected_ForConsumer_when_injectForConsumer_then_returnsInjected() throws {
+        let defaultInstance = InterfaceMock()
+        let injectedInstance = InterfaceMock()
+        @Injected(as: Interface.self, into: Self.self) var sut = { defaultInstance }
+        
+        DependencyContainer.default
+            .inject(injectedInstance, of: Interface.self, for: Self.self)
+        
+        XCTAssertEqual(ObjectIdentifier(injectedInstance), ObjectIdentifier(sut))
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Decore",
     platforms: [
-        .macOS(.v10_14),
+        .macOS(.v10_15),
         .iOS(.v15),
         .watchOS(.v7),
         .tvOS(.v14),
@@ -14,7 +14,6 @@ let package = Package(
         .library(name: "Decore", targets: ["Decore"]),
         .library(name: "DependencyAutoGraph", targets: ["DependencyAutoGraph"]),
         .library(name: "DependencyContainer", targets: ["DependencyContainer"]),
-        .library(name: "EffectBus", targets: ["EffectBus"]),
         .library(name: "ObservableStorage", targets: ["ObservableStorage"]),
     ],
     dependencies: [
@@ -23,7 +22,9 @@ let package = Package(
         // Decore -
         .target(
             name: "Decore",
-            dependencies: ["DependencyAutoGraph",],
+            dependencies: [
+                "DependencyContainer",
+            ],
             path: "Decore/Sources"
         ),
         .testTarget(
@@ -52,17 +53,6 @@ let package = Package(
             name: "DependencyContainer-Tests",
             dependencies: ["DependencyContainer"],
             path: "DependencyContainer/Tests"
-        ),
-        // EffectBus -
-        .target(
-            name: "EffectBus",
-            dependencies: [],
-            path: "EffectBus/Sources"
-        ),
-        .testTarget(
-            name: "EffectBus-Tests",
-            dependencies: ["EffectBus"],
-            path: "EffectBus/Tests"
         ),
         // ObservableStorage -
         .target(


### PR DESCRIPTION
Initial implementation of Dependency Container.

Idea is to use interface protocol name and a consumer class name as a compound key to a dictionary with instances.

```swift
@Injected(as: SomeProtocol.self) var myService = { SomeImplementation() }
```
this gives us "SomeProtocol" + "Any" as a key, and if instance is not yet in the storage, we call `{ SomeImplementation() }` to obtain and save it.

this is a usage when we don't need a specific instance.

```swift
@Injected(as: SomeProtocol.self, into: MyClass.self) var myService = { SomeImplementation() }
```

this will resolve as instance for "SomeProtocol" + "MyClass" as a key.

the key itself includes full reflection of the type.


